### PR TITLE
Enrich Module_custom_of_json

### DIFF
--- a/src/val.ml
+++ b/src/val.ml
@@ -426,7 +426,7 @@ module Impl = struct
       |} client_fun ctx chunked body_param result_cont to_json io_module (of_json ())
       | Module module_name ->
           let of_json module_name =
-            let pure = sprintf "print_endline body; %s.of_yojson json" module_name in
+            let pure = sprintf "(print_endline body; %s.of_yojson json)" module_name in
             if streaming
             then sprintf "Ok (Io_helper.map_stream (fun json -> %s |> function Ok x -> x | Error _ -> failwith (Yojson.Safe.to_string json)) json)" pure
             else pure in

--- a/src/val.ml
+++ b/src/val.ml
@@ -129,7 +129,7 @@ module Impl = struct
   type return =
     | Module of string
     | Type of string
-    | Module_custom_of_json of (unit -> string)
+    | Module_custom_of_json of ((string -> string) * string)
 
   type io = [`Lwt | `Async]
 
@@ -418,15 +418,15 @@ module Impl = struct
         | `Lwt -> "Lwt", "?ctx"
         | `Async -> "Async.Deferred", "" in
       match return with
-      | Module_custom_of_json of_json ->
+      | Module_custom_of_json (of_json, m) ->
           sprintf {|
         Client.%s %s %s ?headers%s uri >>= %s
         let json = %s body in
         %s.return (if code >= 200 && code < 300 then Ok (%s) else Error "Unable to start stream")
-      |} client_fun ctx chunked body_param result_cont to_json io_module (of_json ())
+      |} client_fun ctx chunked body_param result_cont to_json io_module (of_json m)
       | Module module_name ->
           let of_json module_name =
-            let pure = sprintf "(print_endline body; %s.of_yojson json)" module_name in
+            let pure = sprintf "%s.of_yojson json" module_name in
             if streaming
             then sprintf "Ok (Io_helper.map_stream (fun json -> %s |> function Ok x -> x | Error _ -> failwith (Yojson.Safe.to_string json)) json)" pure
             else pure in

--- a/src/val.ml
+++ b/src/val.ml
@@ -426,7 +426,7 @@ module Impl = struct
       |} client_fun ctx chunked body_param result_cont to_json io_module (of_json ())
       | Module module_name ->
           let of_json module_name =
-            let pure = sprintf "%s.of_yojson json" module_name in
+            let pure = sprintf "print_endline body; %s.of_yojson json" module_name in
             if streaming
             then sprintf "Ok (Io_helper.map_stream (fun json -> %s |> function Ok x -> x | Error _ -> failwith (Yojson.Safe.to_string json)) json)" pure
             else pure in

--- a/src/val.mli
+++ b/src/val.mli
@@ -35,7 +35,7 @@ module Impl : sig
   type return =
     | Module of string
     | Type of string
-    | Module_custom_of_json of (unit -> string)
+    | Module_custom_of_json of ((string -> string) * string)
   type io = [`Lwt | `Async]
   type http_request =
     { verb : http_verb


### PR DESCRIPTION
Before:
```ocaml 
type return =
| ...
| Module_custom_of_json of (unit -> string)
```

After:
```ocaml 
type return =
| ...
| Module_custom_of_json of ((string -> string) * string)
```

This allows the input to the function to be changed before the function is applied.